### PR TITLE
Remove unnecessary Apache Commons (commons-lang3) dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,9 +39,6 @@ subprojects {
         // Request signing
         implementation("commons-codec:commons-codec:1.15")
 
-        // Parameters validation
-        implementation("org.apache.commons:commons-lang3:3.11")
-
         // Testing
         testImplementation("junit:junit:4.13")
     }

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/ClientExtensions.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/ClientExtensions.kt
@@ -1,7 +1,6 @@
 package com.westwinglabs.coinbase
 
 import com.westwinglabs.coinbase.service.CoinbaseService
-import org.apache.commons.lang3.Validate
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -24,7 +23,7 @@ internal fun <T> retrofit2.Call<T>.enqueueWith(callback: CoinbaseCallback<T>) {
 }
 
 internal fun CoinbaseService.validatePrivate(apiKey: String, apiPassphrase: String): CoinbaseService {
-    Validate.notBlank(apiKey, "API key is required to invoke this method.")
-    Validate.notBlank(apiPassphrase, "API passphrase is required to invoke this method.")
+    check(!apiKey.isNotBlank()) { "API key is required to invoke this method." }
+    check(!apiPassphrase.isNotBlank()) { "API passphrase is required to invoke this method." }
     return this
 }

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/ClientExtensions.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/ClientExtensions.kt
@@ -23,7 +23,7 @@ internal fun <T> retrofit2.Call<T>.enqueueWith(callback: CoinbaseCallback<T>) {
 }
 
 internal fun CoinbaseService.validatePrivate(apiKey: String, apiPassphrase: String): CoinbaseService {
-    check(!apiKey.isNotBlank()) { "API key is required to invoke this method." }
-    check(!apiPassphrase.isNotBlank()) { "API passphrase is required to invoke this method." }
+    check(apiKey.isNotBlank()) { "API key is required to invoke this method." }
+    check(apiPassphrase.isNotBlank()) { "API passphrase is required to invoke this method." }
     return this
 }

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/CoinbaseClient.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/CoinbaseClient.kt
@@ -38,9 +38,9 @@ class CoinbaseClient(
     private lateinit var webSocket: WebSocket
 
     init {
-        check(!appId.isNotBlank()) { "App ID cannot be empty." }
-        check(!apiEndpoint.isNotBlank()) { "API endpoint cannot be empty." }
-        check(!feedEndpoint.isNotBlank()) { "Websocket endpoint cannot be empty." }
+        check(appId.isNotBlank()) { "App ID cannot be empty." }
+        check(apiEndpoint.isNotBlank()) { "API endpoint cannot be empty." }
+        check(feedEndpoint.isNotBlank()) { "Websocket endpoint cannot be empty." }
 
         val clientWithSigning = okHttpClient.newBuilder()
             .addInterceptor(HeaderInterceptor(apiSecret, appId))

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/CoinbaseClient.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/CoinbaseClient.kt
@@ -9,7 +9,6 @@ import com.westwinglabs.coinbase.websocket.UnsubscribeRequest
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.WebSocket
-import org.apache.commons.lang3.Validate
 import org.joda.time.DateTime
 import org.joda.time.format.ISODateTimeFormat
 import retrofit2.Retrofit
@@ -39,9 +38,9 @@ class CoinbaseClient(
     private lateinit var webSocket: WebSocket
 
     init {
-        Validate.notBlank(appId, "App ID cannot be empty.")
-        Validate.notBlank(apiEndpoint, "API endpoint cannot be empty.")
-        Validate.notBlank(feedEndpoint, "Websocket endpoint cannot be empty.")
+        check(!appId.isNotBlank()) { "App ID cannot be empty." }
+        check(!apiEndpoint.isNotBlank()) { "API endpoint cannot be empty." }
+        check(!feedEndpoint.isNotBlank()) { "Websocket endpoint cannot be empty." }
 
         val clientWithSigning = okHttpClient.newBuilder()
             .addInterceptor(HeaderInterceptor(apiSecret, appId))


### PR DESCRIPTION
Remove uses of `Validate` in favor of Kotlin's stdlib `check`. This allows removing one third-party dependency from the project.