### PR TITLE
Replace SLF4J with Log4j2

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
     // OkHttp logging
     implementation("com.squareup.okhttp3:logging-interceptor:3.14.9")
 
-    // SLF4J (implementation)
-    implementation("org.slf4j:slf4j-simple:1.7.30")
+    // Log4j2 (implementation)
+    implementation("org.apache.logging.log4j:log4j-core:2.13.3")
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -13,8 +13,8 @@ tasks.withType<ProcessResources> {
 }
 
 dependencies {
-    // SLF4J (API only)
-    implementation("org.slf4j:slf4j-api:1.7.30")
+    // Log4j2 (API only)
+    implementation("org.apache.logging.log4j:log4j-api:2.13.3")
 
     // Testing
     testImplementation("com.squareup.okhttp3:mockwebserver:3.14.9")

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/ClientModels.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/ClientModels.kt
@@ -1,10 +1,10 @@
 package com.westwinglabs.coinbase
 
-import org.slf4j.LoggerFactory
+import org.apache.logging.log4j.LogManager
 
 abstract class CoinbaseCallback<T> {
 
-    private val logger = LoggerFactory.getLogger("CoinbaseCallback")
+    private val logger = LogManager.getLogger()
 
     abstract fun onResponse(result: T?)
 


### PR DESCRIPTION
There's no Log4j2 implementation for SLF4J, and Log4j2 seems more versatile (Log4j2 also has a bridge to SLF4J if that was necessary).