### PR TITLE
Clarify interceptors order and headers values

### DIFF
--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/CoinbaseClient.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/CoinbaseClient.kt
@@ -42,6 +42,10 @@ class CoinbaseClient(
         check(apiEndpoint.isNotBlank()) { "API endpoint cannot be empty." }
         check(feedEndpoint.isNotBlank()) { "Websocket endpoint cannot be empty." }
 
+        // Note that if a logging interceptor is set by the app, it will not
+        // be able to log the values of the headers added by HeaderInterceptor,
+        // because the chain is executed in order (and HeaderInterceptor comes
+        // last).
         val clientWithSigning = okHttpClient.newBuilder()
             .addInterceptor(HeaderInterceptor(apiSecret, appId))
             .build()

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/auth/HeaderInterceptor.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/auth/HeaderInterceptor.kt
@@ -7,6 +7,12 @@ import okhttp3.Response
 import okio.Buffer
 import java.util.*
 
+/**
+ * This class adds a number of headers to a request:
+ * - CoinbaseService.HEADER_USER_AGENT (all requests)
+ * - CoinbaseService.HEADER_TIMESTAMP (when signature is required)
+ * - CoinbaseService.HEADER_SIGN (when signature is required)
+ */
 internal class HeaderInterceptor(
     private val apiSecret: String,
     private val appId: String
@@ -27,7 +33,7 @@ internal class HeaderInterceptor(
 
         // Always add a user agent
         // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
-        newRequest.addHeader("User-Agent", "CoinbaseKotlin/$version ($appId)")
+        newRequest.addHeader(CoinbaseService.HEADER_USER_AGENT, "CoinbaseKotlin/$version ($appId)")
 
         // Only sign requests that include the API key
         val key = request.header(CoinbaseService.HEADER_KEY)

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/service/CoinbaseService.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/service/CoinbaseService.kt
@@ -6,6 +6,9 @@ import retrofit2.http.*
 internal interface CoinbaseService {
 
     companion object {
+        // All requests will include this header
+        const val HEADER_USER_AGENT = "User-Agent"
+
         // If values for these headers are set, request will be signed.
         const val HEADER_KEY = "CB-ACCESS-KEY"
         const val HEADER_PASSPHRASE = "CB-ACCESS-PASSPHRASE"


### PR DESCRIPTION
Particularly, if a logging interceptor is set by the app, it will not be able to log the values of the headers added by `HeaderInterceptor`, because the chain is executed in order (and `HeaderInterceptor` comes last).