### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@
 All notable changes to this project will be documented in this file.
 We welcome the participation and contributions from everyone.
 
-## [Unreleased]
+## [0.2.0] - 2020-11-02
 
-- N/A
+- Introduce the header interceptor at the beginning of the HTTP request chain [#10](https://github.com/westwinglabs/coinbase-kotlin/pull/10) [#11](https://github.com/westwinglabs/coinbase-kotlin/pull/11)
+- Add option to the sample CLI to specify endpoint type [#9](https://github.com/westwinglabs/coinbase-kotlin/pull/9)
+- Replace SLF4J with Log4j2 [#5](https://github.com/westwinglabs/coinbase-kotlin/pull/5) [#7](https://github.com/westwinglabs/coinbase-kotlin/pull/7) [#8](https://github.com/westwinglabs/coinbase-kotlin/pull/8)
+- Remove unnecessary Apache Commons (`commons-lang3`) dependency [#4](https://github.com/westwinglabs/coinbase-kotlin/pull/4)
 
 ## [0.1.0] - 2020-10-10
-
-### Added
 
 - Initial release with support for public, private, and websocket APIs.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PATH_JAR=./cli/build/libs/cli-0.1.0-SNAPSHOT-all.jar
+PATH_JAR=./cli/build/libs/cli-0.2.0-SNAPSHOT-all.jar
 
 JAVA_PUBLIC_COMMAND=java -jar $(PATH_JAR)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ repositories {
 2. Add the dependency to your project:
 
 ```
-implementation 'com.westwinglabs:coinbase-kotlin:0.1.0'
+implementation 'com.westwinglabs:coinbase-kotlin:0.2.0'
 ```
 
 For Maven instructions, [visit the project page](https://bintray.com/westwinglabs/coinbase/coinbase-kotlin) on Bintray.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,8 @@
 
 ## Publish the artifacts
 
+Release ticket checklist:
+
 - [ ] Cut a release branch, e.g. `release-v0.1.0`.
 - [ ] Update the `CHANGELOG.md` file with a summary of the milestone. 
 - [ ] Update the version number in the root `README.md` and `Makefile` files.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,10 @@
 
 ## Publish the artifacts
 
-1. Cut a release branch, e.g. `release-v0.1.0`.
-1. Update the version number in the root `build.gradle.kts` file (e.g. `version = "0.1.0"`). This will be the release number in the POM file.
-1. Update the version number in the root `README.md` file.
-1. Create a new release (e.g. tag `v0.1.0`) targeting the release branch. This will trigger a GitHub action that will automatically upload the artifact to Bintray.
+- [ ] Cut a release branch, e.g. `release-v0.1.0`.
+- [ ] Update the `CHANGELOG.md` file with a summary of the milestone. 
+- [ ] Update the version number in the root `README.md` and `Makefile` files.
+- [ ] Remove `-SNAPSHOT` from the version number in the root `build.gradle.kts` file (e.g. `version = "0.1.0"`). This will be the release number in the POM file.
+- [ ] Create a new release (e.g. tag `v0.1.0`) targeting the release branch with the content in `CHANGELOG.md`. This will trigger a GitHub action that will automatically upload the artifact to Bintray.
+- [ ] Update the version number in the root `build.gradle.kts` file to the next SNAPSHOT value (e.g. `version = "0.2.0-SNAPSHOT"`).
+- [ ] Merge the PR.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.westwinglabs"
-    version = "0.1.0-SNAPSHOT"
+    version = "0.2.0"
 
     repositories {
         jcenter()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.westwinglabs"
-    version = "0.2.0"
+    version = "0.3.0-SNAPSHOT"
 
     repositories {
         jcenter()


### PR DESCRIPTION
- [x] Cut a release branch, e.g. `release-v0.1.0`.
- [x] Update the `CHANGELOG.md` file with a summary of the milestone. 
- [x] Update the version number in the root `README.md` and `Makefile` files.
- [x] Remove `-SNAPSHOT` from the version number in the root `build.gradle.kts` file (e.g. `version = "0.1.0"`). This will be the release number in the POM file.
- [x] Create a new release (e.g. tag `v0.1.0`) targeting the release branch with the content in `CHANGELOG.md`. This will trigger a GitHub action that will automatically upload the artifact to Bintray.
- [x] Update the version number in the root `build.gradle.kts` file to the next SNAPSHOT value (e.g. `version = "0.2.0-SNAPSHOT"`).
- [x] Merge the PR.
