### PR TITLE
Migrate from Bintray to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
           java-version: 8
       - name: Grant execute permission for Gradle
         run: chmod +x gradlew
-      - name: Publish to Bintray
-        run: ./gradlew :lib:bintrayUpload
+      - name: Publish to GitHub Packages
+        run: ./gradlew :lib:publish
         env:
-          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ implementation 'com.westwinglabs:coinbase-kotlin:0.3.0'
 
 For more information on how to set up Gradle for use with GitHub Packages [visit this guide](https://docs.github.com/en/packages/guides/configuring-gradle-for-use-with-github-packages).
 
-
 ## Usage
 
 The following code snippets are extracted from the [sample CLI app](cli) included with this project.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![build](https://github.com/westwinglabs/coinbase-kotlin/workflows/build/badge.svg)
-[ ![Download](https://api.bintray.com/packages/westwinglabs/coinbase/coinbase-kotlin/images/download.svg) ](https://bintray.com/westwinglabs/coinbase/coinbase-kotlin/_latestVersion)
 
 # Coinbase (Kotlin/Java)
 
@@ -8,12 +7,12 @@ It targets Java 8 and includes minimal dependencies so that it can be used acros
 
 ## Installation
 
-1. Set up the Bintray repo:
+1. Set up GitHub Packages:
 
 ```
 repositories {
     maven {
-        url  "https://dl.bintray.com/westwinglabs/coinbase" 
+        url "https://maven.pkg.github.com/westwinglabs/coinbase-kotlin" 
     }
 }
 ```
@@ -24,7 +23,7 @@ repositories {
 implementation 'com.westwinglabs:coinbase-kotlin:0.3.0'
 ```
 
-For Maven instructions, [visit the project page](https://bintray.com/westwinglabs/coinbase/coinbase-kotlin) on Bintray.
+For more information on how to set up Gradle for use with GitHub Packages [visit this guide](https://docs.github.com/en/packages/guides/configuring-gradle-for-use-with-github-packages).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ implementation 'com.westwinglabs:coinbase-kotlin:0.3.0'
 
 For more information on how to set up Gradle for use with GitHub Packages [visit this guide](https://docs.github.com/en/packages/guides/configuring-gradle-for-use-with-github-packages).
 
+
 ## Usage
 
 The following code snippets are extracted from the [sample CLI app](cli) included with this project.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,6 @@ Release ticket checklist:
 - [ ] Update the `CHANGELOG.md` file with a summary of the milestone. 
 - [ ] Update the version number in the root `README.md` (new version) and `Makefile` (next version) files.
 - [ ] Remove `-SNAPSHOT` from the version number in the root `build.gradle.kts` file (e.g. `version = "0.1.0"`). This will be the release number in the POM file.
-- [ ] Create a new release (e.g. tag `v0.1.0`) targeting the release branch with the content in `CHANGELOG.md`. This will trigger a GitHub action that will automatically upload the artifact to Bintray.
+- [ ] Create a new release (e.g. tag `v0.1.0`) targeting the release branch with the content in `CHANGELOG.md`. This will trigger a GitHub action that will automatically upload the artifact to GitHub Packages.
 - [ ] Update the version number in the root `build.gradle.kts` file to the next SNAPSHOT value (e.g. `version = "0.2.0-SNAPSHOT"`).
 - [ ] Merge the PR.

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     `java-library`
     `maven-publish`
     signing
-    id("com.jfrog.bintray") version "1.8.5"
     id("org.jetbrains.dokka") version "1.4.20"
 }
 
@@ -26,28 +25,20 @@ java {
     withSourcesJar()
 }
 
-bintray {
-    user = "westwinglabs"
-    key = System.getenv("BINTRAY_KEY")
-    publish = true
-    setPublications("maven")
+publishing {
 
-    with(pkg) {
-        repo = "coinbase"
-        name = "coinbase-kotlin"
-        description = "Kotlin/Java client for Coinbase Pro."
-        setLicenses("Apache-2.0")
-        vcsUrl = "https://github.com/westwinglabs/coinbase-kotlin.git"
-        websiteUrl = "https://github.com/westwinglabs/coinbase-kotlin"
-        issueTrackerUrl = "https://github.com/westwinglabs/coinbase-kotlin/issues"
-
-        with(version) {
-            name = project.version.toString()
+    // See: https://docs.github.com/en/actions/guides/publishing-java-packages-with-gradle
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            setUrl("https://maven.pkg.github.com/westwinglabs/coinbase-kotlin")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
         }
     }
-}
 
-publishing {
     publications {
         create<MavenPublication>("maven") {
             from(components["java"])
@@ -64,7 +55,7 @@ publishing {
                 licenses {
                     license {
                         name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                        url.set("https://www.apache.org/licenses/LICENSE-2.0.txt")
                     }
                 }
 
@@ -79,7 +70,7 @@ publishing {
                 scm {
                     connection.set("scm:git:git://github.com/westwinglabs/coinbase-kotlin.git")
                     developerConnection.set("scm:git:ssh://github.com/westwinglabs/coinbase-kotlin.git")
-                    url.set("http://github.com/westwinglabs/coinbase-kotlin")
+                    url.set("https://github.com/westwinglabs/coinbase-kotlin")
                 }
             }
         }


### PR DESCRIPTION
All Bintray services will be deprecated on May 1st 2021. This PR removes Bintray settings and move the publishing flow to GitHub packages.
