### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 We welcome the participation and contributions from everyone.
 
+## [0.4.0] - 2021-04-16
+
+Note: Starting with this version, artifacts are now available on GitHub Packages. Bintray is no longer supported.
+
+- Add functionality for authentication of subscription requests [#21](https://github.com/westwinglabs/coinbase-kotlin/pull/21)
+- Add post parameters for orders [#23](https://github.com/westwinglabs/coinbase-kotlin/pull/23)
+- Ticker `sequence` and `trade_id` fields should be long [#16](https://github.com/westwinglabs/coinbase-kotlin/pull/16) [#17](https://github.com/westwinglabs/coinbase-kotlin/pull/17)
+- Bump stable dependencies [#18](https://github.com/westwinglabs/coinbase-kotlin/pull/18) [#18](https://github.com/westwinglabs/coinbase-kotlin/pull/22)
+
 ## [0.3.0] - 2020-11-19
 
 - Update to Kotlin 1.4 [#6](https://github.com/westwinglabs/coinbase-kotlin/pull/6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Note: Starting with this version, artifacts are now available on GitHub Packages
 - Add functionality for authentication of subscription requests [#21](https://github.com/westwinglabs/coinbase-kotlin/pull/21)
 - Add post parameters for orders [#23](https://github.com/westwinglabs/coinbase-kotlin/pull/23)
 - Ticker `sequence` and `trade_id` fields should be long [#16](https://github.com/westwinglabs/coinbase-kotlin/pull/16) [#17](https://github.com/westwinglabs/coinbase-kotlin/pull/17)
-- Bump stable dependencies [#18](https://github.com/westwinglabs/coinbase-kotlin/pull/18) [#18](https://github.com/westwinglabs/coinbase-kotlin/pull/22)
+- Bump stable dependencies [#18](https://github.com/westwinglabs/coinbase-kotlin/pull/18) [#22](https://github.com/westwinglabs/coinbase-kotlin/pull/22)
 
 ## [0.3.0] - 2020-11-19
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PATH_JAR=./cli/build/libs/cli-0.4.0-SNAPSHOT-all.jar
+PATH_JAR=./cli/build/libs/cli-0.5.0-SNAPSHOT-all.jar
 
 JAVA_PUBLIC_COMMAND=java -jar $(PATH_JAR)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repositories {
 2. Add the dependency to your project:
 
 ```
-implementation 'com.westwinglabs:coinbase-kotlin:0.3.0'
+implementation 'com.westwinglabs:coinbase-kotlin:0.4.0'
 ```
 
 For more information on how to set up Gradle for use with GitHub Packages [visit this guide](https://docs.github.com/en/packages/guides/configuring-gradle-for-use-with-github-packages).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.westwinglabs"
-    version = "0.4.0"
+    version = "0.5.0-SNAPSHOT"
 
     repositories {
         jcenter()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "com.westwinglabs"
-    version = "0.4.0-SNAPSHOT"
+    version = "0.4.0"
 
     repositories {
         jcenter()


### PR DESCRIPTION
Starting with this version, artifacts are now available on GitHub Packages. Bintray is no longer supported.