### PR TITLE
Fix timestamp to double bug in candle stick response

### DIFF
--- a/cli/src/main/kotlin/com/westwinglabs/coinbase/cli/CoinbaseCli.kt
+++ b/cli/src/main/kotlin/com/westwinglabs/coinbase/cli/CoinbaseCli.kt
@@ -21,7 +21,11 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.apache.commons.cli.CommandLine
 import org.apache.logging.log4j.LogManager
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.format.DateTimeFormatter
 import java.io.File
+import kotlin.reflect.jvm.internal.impl.builtins.StandardNames.FqNames.string
 
 open class CoinbaseCli : FeedListener() {
 
@@ -79,8 +83,14 @@ open class CoinbaseCli : FeedListener() {
             .cache(Cache(File("/tmp"), 10 * 1_024 * 1_024)) // 10 MB in bytes
             .build()
 
+        val formatter: DateTimeFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+
         val client = CoinbaseClient(apiEndpoint = getEndpoints(parsed).first, okHttpClient = okHttpClient)
-        val response = client.getProducts()
+        val response = client.getProductCandles(
+            "BTC-USD",
+            formatter.parseDateTime("2021-08-07T18:00:00.000Z"),
+            formatter.parseDateTime("2021-08-07T18:30:00.000Z")
+        )
         client.close()
 
         printEncoded(response)

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/service/CoinbaseService.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/service/CoinbaseService.kt
@@ -428,7 +428,7 @@ internal interface CoinbaseService {
         @Query("start") start: String?,
         @Query("end") end: String?,
         @Query("granularity") granularity: Int?
-    ): Call<List<List<Double>>>
+    ): Call<List<List<String>>>
 
     @GET(PATH_PUBLIC_GET_PRODUCT_STATS)
     fun getProductStats(@Path("productId") productId: String): Call<ProductStatsResponse>

--- a/lib/src/main/kotlin/com/westwinglabs/coinbase/service/ServicePublicModels.kt
+++ b/lib/src/main/kotlin/com/westwinglabs/coinbase/service/ServicePublicModels.kt
@@ -1,6 +1,7 @@
 package com.westwinglabs.coinbase.service
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.math.BigDecimal
 
 class ProductsResponse : ArrayList<ProductsResponseItem>()
 
@@ -110,3 +111,22 @@ data class TimeResponse(
     @JsonProperty("epoch") val epoch: Double,
     @JsonProperty("iso") val iso: String
 )
+
+/*
+    time bucket start time
+    low lowest price during the bucket interval
+    high highest price during the bucket interval
+    open opening price (first trade) in the bucket interval
+    close closing price (last trade) in the bucket interval
+    volume volume of trading activity during the bucket interval
+ */
+data class ProductCandlesResponseItem(
+    @JsonProperty("time") val time: Long,
+    @JsonProperty("low") val low: BigDecimal,
+    @JsonProperty("high") val high: BigDecimal,
+    @JsonProperty("open") val open: BigDecimal,
+    @JsonProperty("close") val close: BigDecimal,
+    @JsonProperty("volume") val volume: BigDecimal,
+)
+
+typealias ProductCandlesResponse  = List<ProductCandlesResponseItem>


### PR DESCRIPTION
Currently the response from `GET /products/{productId}/candles` is converting what should be a `timestamp` to a `double`.

Expected response:
 ```
[ [ 16283917839, 44014.46, 44036.46, 44030.24, 44036.44, 0.00272361 ], ...
```

Actual Response: 
 ```
[ [ 1.62839178E9, 44014.46, 44036.46, 44030.24, 44036.44, 0.00272361 ], ...
```

This pr makes the response for the call to get candles math the expected response.

Also in general [we should avoid returning `Double`](url) as there may be a chance that user's of the library may need to do calculations with the data returned and it is generally desirable to use `BigDecimal` instead.